### PR TITLE
Format tags array to display as one string

### DIFF
--- a/assets/scripts/photo/ui.js
+++ b/assets/scripts/photo/ui.js
@@ -19,7 +19,6 @@ const onIndexPhotosSuccess = function (data) {
 
 const onIndexPhotosFailure = function (data) {
   $('#nav-message').text('Create Photo Failure')
-  console.log(data)
 }
 
 module.exports = {

--- a/assets/scripts/templates/helpers/tags-display.js
+++ b/assets/scripts/templates/helpers/tags-display.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const tagsDisplay = (tagsArray) => {
+  // given an array of tags, return a single string joining all the tags
+  // with a comma and a space for display
+  return tagsArray.join(', ')
+}
+
+module.exports = tagsDisplay

--- a/assets/scripts/templates/index-display.handlebars
+++ b/assets/scripts/templates/index-display.handlebars
@@ -5,7 +5,7 @@
     </h3>
     <p> Tags:
       {{#if photo.tags.[0]}}
-        {{photo.tags}}
+        {{tags-display photo.tags}}
       {{else}}
         No data provided
       {{/if}}


### PR DESCRIPTION
Get events for photos take the array the API responds with and reformats
it as a string, with array elements separated by a comma and a single
space

Along with https://github.com/Po-Ta-Toes/subidos-api/pull/23,
Close #24